### PR TITLE
修复 Star History 图表失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ## Star History
 ** 喜欢的话可以点个Star哦 **
-[![Star History Chart](https://api.star-history.com/svg?repos=jedzqer/manga-translator-android&type=date&legend=top-left)](https://www.star-history.com/#jedzqer/manga-translator-android&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jedzqer/manga-translator-android&type=date&legend=top-left)](https://star-history.dera.page/#jedzqer/manga-translator-android&type=date&legend=top-left)
 
 
 ## 数据与文件说明 🗂️

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,7 +51,7 @@ Join the QQ group for questions and discussion: `1080302768`
 
 ## Star History
 ** If you like this project, please consider giving it a star **
-[![Star History Chart](https://api.star-history.com/svg?repos=jedzqer/manga-translator-android&type=date&legend=top-left)](https://www.star-history.com/#jedzqer/manga-translator-android&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jedzqer/manga-translator-android&type=date&legend=top-left)](https://star-history.dera.page/#jedzqer/manga-translator-android&type=date&legend=top-left)
 
 ## Data and File Layout 🗂️
 - Manga library storage: `/Android/data/<package>/files/manga_library/`


### PR DESCRIPTION
当前 Star History 图表因 GitHub API 限制已经无法正常加载，这是一个必须修复的问题。已将图表切换到新的可用域名 star-history.dera.page，恢复 Star 历史图表的正常显示。